### PR TITLE
Update CircleCI config.yml to build develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,14 @@ workflows:
             - build_client
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - develop
       - deploy_server:
           requires:
             - build_server
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - develop


### PR DESCRIPTION
this update will make CircleCi build trigger on both master and develop branch, but they both deploy to same heroku environment. Next step is to have two separate environments (i.e. Production and Testing environments)