### PR TITLE
Remove service worker

### DIFF
--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -8,7 +8,7 @@
       "type": "image/x-icon"
     }
   ],
-  "start_url": "./index.html",
+  "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,7 +2,5 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./containers/App/App";
-import registerServiceWorker from "./registerServiceWorker";
 
 ReactDOM.render(<App />, document.getElementById("root"));
-registerServiceWorker();


### PR DESCRIPTION
- Changes `manifest.json` `start_url` to `/` as per https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#serving-apps-with-client-side-routing
- Removes service worker otherwise requests to `/api` and `/admin` are handled by the service worker and `index.html` is incorrectly served